### PR TITLE
Safu governance

### DIFF
--- a/contracts/XPool.sol
+++ b/contracts/XPool.sol
@@ -291,6 +291,7 @@ contract XPool is XApollo, XPToken, XConst {
         _lock_
     {
         require(finalized, "ERR_NOT_FINALIZED");
+        require(maxAmountsIn.length == _tokens.length, "ERR_LENGTH_MISMATCH");
 
         uint256 poolTotal = totalSupply();
         uint256 ratio = poolAmountOut.bdiv(poolTotal);
@@ -315,6 +316,7 @@ contract XPool is XApollo, XPToken, XConst {
         _lock_
     {
         require(finalized, "ERR_NOT_FINALIZED");
+        require(minAmountsOut.length == _tokens.length, "ERR_LENGTH_MISMATCH");
 
         uint256 poolTotal = totalSupply();
         uint256 _exitFee = poolAmountIn.bmul(exitFee);

--- a/contracts/XPool.sol
+++ b/contracts/XPool.sol
@@ -347,7 +347,7 @@ contract XPool is XApollo, XPToken, XConst {
         address tokenOut,
         uint256 minAmountOut,
         uint256 maxPrice
-    ) external _lock_ returns (uint256 tokenAmountOut, uint256 spotPriceAfter) {
+    ) external returns (uint256 tokenAmountOut, uint256 spotPriceAfter) {
         return
             swapExactAmountInRefer(
                 tokenIn,
@@ -455,7 +455,7 @@ contract XPool is XApollo, XPToken, XConst {
         address tokenOut,
         uint256 tokenAmountOut,
         uint256 maxPrice
-    ) external _lock_ returns (uint256 tokenAmountIn, uint256 spotPriceAfter) {
+    ) external returns (uint256 tokenAmountIn, uint256 spotPriceAfter) {
         return
             swapExactAmountOutRefer(
                 tokenIn,

--- a/contracts/XPool.sol
+++ b/contracts/XPool.sol
@@ -102,13 +102,12 @@ contract XPool is XApollo, XPToken, XConst {
     uint256 private _totalWeight;
 
     IXConfig public xconfig;
-    // if(tx.origin == FarmPoolCreator) is xdex farm pool
     address public origin;
 
     constructor(address _xconfig, address _controller) public {
         controller = _controller;
         origin = tx.origin;
-        swapFee = SWAP_FEES[1]; //default 0.3%
+        swapFee = SWAP_FEES[1];
         exitFee = EXIT_ZERO_FEE;
         finalized = false;
         xconfig = IXConfig(_xconfig);
@@ -436,14 +435,13 @@ contract XPool is XApollo, XPToken, XConst {
             referrer != msg.sender &&
             referrer != tx.origin
         ) {
-            referFee = _swapFee / 5; // 20%
+            referFee = _swapFee / 5; // 20% to referrer
             _pushUnderlying(tokenIn, referrer, referFee);
             emit LOG_REFER(msg.sender, referrer, tokenIn, referFee);
         }
 
-        uint256 safuFee = tokenAmountIn / 2000; // 0.05%
-        //is farm pool
-        if (xconfig.getFarmCreator() == origin) {
+        uint256 safuFee = tokenAmountIn.bmul(xconfig.getSafuFee()); // to SAFU
+        if (xconfig.isFarmPool(address(this))) {
             safuFee = _swapFee.bsub(referFee);
         }
         _pushUnderlying(tokenIn, xconfig.getSAFU(), safuFee);
@@ -545,14 +543,13 @@ contract XPool is XApollo, XPToken, XConst {
             referrer != msg.sender &&
             referrer != tx.origin
         ) {
-            referFee = _swapFee / 5; // 20%
+            referFee = _swapFee / 5; // 20% to referrer
             _pushUnderlying(tokenIn, referrer, referFee);
             emit LOG_REFER(msg.sender, referrer, tokenIn, referFee);
         }
 
-        uint256 safuFee = tokenAmountIn / 2000; // 0.05%
-        //is farm pool
-        if (xconfig.getFarmCreator() == origin) {
+        uint256 safuFee = tokenAmountIn.bmul(xconfig.getSafuFee()); // to SAFU
+        if (xconfig.isFarmPool(address(this))) {
             safuFee = _swapFee.bsub(referFee);
         }
         _pushUnderlying(tokenIn, xconfig.getSAFU(), safuFee);
@@ -592,10 +589,8 @@ contract XPool is XApollo, XPToken, XConst {
         _mintPoolShare(poolAmountOut);
         _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
 
-        //TODO: in same function
-        uint256 _swapFee = tokenAmountIn / 2000; // 0.05%
-        //is farm pool
-        if (xconfig.getFarmCreator() == origin) {
+        uint256 _swapFee = tokenAmountIn.bmul(xconfig.getSafuFee()); // to SAFU
+        if (xconfig.isFarmPool(address(this))) {
             _swapFee = tokenAmountIn.bmul(swapFee);
         }
         _pushUnderlying(tokenIn, xconfig.getSAFU(), _swapFee);
@@ -641,9 +636,8 @@ contract XPool is XApollo, XPToken, XConst {
             _pushPoolShare(origin, _exitFee);
         }
 
-        uint256 _swapFee = tokenAmountOut / 2000; // to SAFU
-        //is farm pool
-        if (xconfig.getFarmCreator() == origin) {
+        uint256 _swapFee = tokenAmountOut.bmul(xconfig.getSafuFee()); // to SAFU
+        if (xconfig.isFarmPool(address(this))) {
             _swapFee = tokenAmountOut.bmul(swapFee);
         }
         _pushUnderlying(tokenOut, xconfig.getSAFU(), _swapFee);

--- a/contracts/XPool.sol
+++ b/contracts/XPool.sol
@@ -368,6 +368,7 @@ contract XPool is XApollo, XPToken, XConst {
     ) public _lock_ returns (uint256 tokenAmountOut, uint256 spotPriceAfter) {
         require(_records[tokenIn].bound, "ERR_NOT_BOUND");
         require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(finalized, "ERR_NOT_FINALIZED");
 
         Record storage inRecord = _records[address(tokenIn)];
         Record storage outRecord = _records[address(tokenOut)];
@@ -476,6 +477,7 @@ contract XPool is XApollo, XPToken, XConst {
     ) public _lock_ returns (uint256 tokenAmountIn, uint256 spotPriceAfter) {
         require(_records[tokenIn].bound, "ERR_NOT_BOUND");
         require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(finalized, "ERR_NOT_FINALIZED");
 
         Record storage inRecord = _records[address(tokenIn)];
         Record storage outRecord = _records[address(tokenOut)];

--- a/contracts/XSwapProxyV1.sol
+++ b/contracts/XSwapProxyV1.sol
@@ -176,7 +176,7 @@ contract XSwapProxyV1 is ReentrancyGuard {
     // Pool Management
 
     // key: keccak256(tokens[i], norms[i]), value: bool
-    mapping(bytes32 => bool) internal _pools;
+    //mapping(bytes32 => bool) internal _pools;
 
     function create(
         address factoryAddress,
@@ -191,7 +191,7 @@ contract XSwapProxyV1 is ReentrancyGuard {
         require(tokens.length <= MAX_BOUND_TOKENS, "ERR_MAX_TOKENS");
 
         // check pool exist
-        (bool exist, bytes32 sig) = hasPool(tokens, denorms);
+        (bool exist, bytes32 sig) = xconfig.hasPool(tokens, denorms);
         require(!exist, "ERR_POOL_EXISTS");
 
         // create new pool
@@ -211,39 +211,39 @@ contract XSwapProxyV1 is ReentrancyGuard {
         require(msg.value == 0 || hasETH, "ERR_INVALID_PAY");
         pool.finalize(swapFee);
 
-        _pools[sig] = true;
+        //_pools[sig] = true;
         pool.transfer(msg.sender, pool.balanceOf(address(this)));
 
         return address(pool);
     }
 
     //check pool exist
-    function hasPool(address[] memory tokens, uint256[] memory denorms)
-        public
-        view
-        returns (bool exist, bytes32 sig)
-    {
-        require(tokens.length == denorms.length, "ERR_LENGTH_MISMATCH");
-        require(tokens.length >= MIN_BOUND_TOKENS, "ERR_MIN_TOKENS");
-        require(tokens.length <= MAX_BOUND_TOKENS, "ERR_MAX_TOKENS");
+    // function hasPool(address[] memory tokens, uint256[] memory denorms)
+    //     public
+    //     view
+    //     returns (bool exist, bytes32 sig)
+    // {
+    //     require(tokens.length == denorms.length, "ERR_LENGTH_MISMATCH");
+    //     require(tokens.length >= MIN_BOUND_TOKENS, "ERR_MIN_TOKENS");
+    //     require(tokens.length <= MAX_BOUND_TOKENS, "ERR_MAX_TOKENS");
 
-        uint256 totalWeight = 0;
-        for (uint8 i = 0; i < tokens.length; i++) {
-            totalWeight = totalWeight.add(denorms[i]);
-        }
+    //     uint256 totalWeight = 0;
+    //     for (uint8 i = 0; i < tokens.length; i++) {
+    //         totalWeight = totalWeight.add(denorms[i]);
+    //     }
 
-        bytes memory poolInfo;
-        for (uint8 i = 0; i < tokens.length; i++) {
-            if (i > 0) {
-                require(tokens[i] > tokens[i - 1], "ERR_TOKENS_NOT_SORTED");
-            }
-            //normalized weight (multiplied by 100)
-            uint256 nWeight = denorms[i].mul(100).div(totalWeight);
-            poolInfo = abi.encodePacked(poolInfo, tokens[i], nWeight);
-        }
-        sig = keccak256(poolInfo);
-        exist = _pools[sig];
-    }
+    //     bytes memory poolInfo;
+    //     for (uint8 i = 0; i < tokens.length; i++) {
+    //         if (i > 0) {
+    //             require(tokens[i] > tokens[i - 1], "ERR_TOKENS_NOT_SORTED");
+    //         }
+    //         //normalized weight (multiplied by 100)
+    //         uint256 nWeight = denorms[i].mul(100).div(totalWeight);
+    //         poolInfo = abi.encodePacked(poolInfo, tokens[i], nWeight);
+    //     }
+    //     sig = keccak256(poolInfo);
+    //     exist = _pools[sig];
+    // }
 
     function joinPool(
         address poolAddress,

--- a/contracts/XSwapProxyV1.sol
+++ b/contracts/XSwapProxyV1.sol
@@ -174,10 +174,6 @@ contract XSwapProxyV1 is ReentrancyGuard {
     }
 
     // Pool Management
-
-    // key: keccak256(tokens[i], norms[i]), value: bool
-    //mapping(bytes32 => bool) internal _pools;
-
     function create(
         address factoryAddress,
         address[] calldata tokens,
@@ -211,39 +207,11 @@ contract XSwapProxyV1 is ReentrancyGuard {
         require(msg.value == 0 || hasETH, "ERR_INVALID_PAY");
         pool.finalize(swapFee);
 
-        //_pools[sig] = true;
+        xconfig.addPoolSig(sig);
         pool.transfer(msg.sender, pool.balanceOf(address(this)));
 
         return address(pool);
     }
-
-    //check pool exist
-    // function hasPool(address[] memory tokens, uint256[] memory denorms)
-    //     public
-    //     view
-    //     returns (bool exist, bytes32 sig)
-    // {
-    //     require(tokens.length == denorms.length, "ERR_LENGTH_MISMATCH");
-    //     require(tokens.length >= MIN_BOUND_TOKENS, "ERR_MIN_TOKENS");
-    //     require(tokens.length <= MAX_BOUND_TOKENS, "ERR_MAX_TOKENS");
-
-    //     uint256 totalWeight = 0;
-    //     for (uint8 i = 0; i < tokens.length; i++) {
-    //         totalWeight = totalWeight.add(denorms[i]);
-    //     }
-
-    //     bytes memory poolInfo;
-    //     for (uint8 i = 0; i < tokens.length; i++) {
-    //         if (i > 0) {
-    //             require(tokens[i] > tokens[i - 1], "ERR_TOKENS_NOT_SORTED");
-    //         }
-    //         //normalized weight (multiplied by 100)
-    //         uint256 nWeight = denorms[i].mul(100).div(totalWeight);
-    //         poolInfo = abi.encodePacked(poolInfo, tokens[i], nWeight);
-    //     }
-    //     sig = keccak256(poolInfo);
-    //     exist = _pools[sig];
-    // }
 
     function joinPool(
         address poolAddress,

--- a/contracts/interface/IXConfig.sol
+++ b/contracts/interface/IXConfig.sol
@@ -21,4 +21,7 @@ interface IXConfig {
         external
         view
         returns (bool exist, bytes32 sig);
+
+    // add by XSwapProxy
+    function addPoolSig(bytes32 sig) external;
 }

--- a/contracts/interface/IXConfig.sol
+++ b/contracts/interface/IXConfig.sol
@@ -5,7 +5,7 @@ interface IXConfig {
 
     function getSAFU() external view returns (address);
 
-    function getFarmCreator() external view returns (address);
+    function isFarmPool(address pool) external view returns (bool);
 
     function getMaxExitFee() external view returns (uint256);
 
@@ -24,4 +24,7 @@ interface IXConfig {
 
     // add by XSwapProxy
     function addPoolSig(bytes32 sig) external;
+
+    // remove by XSwapProxy
+    function removePoolSig(bytes32 sig) external;
 }

--- a/contracts/interface/IXConfig.sol
+++ b/contracts/interface/IXConfig.sol
@@ -11,7 +11,14 @@ interface IXConfig {
 
     function getSafuFee() external view returns (uint256);
 
+    function getSwapProxy() external view returns (address);
+
     function ethAddress() external pure returns (address);
 
     function XDEXAddress() external pure returns (address);
+
+    function hasPool(address[] calldata tokens, uint256[] calldata denorms)
+        external
+        view
+        returns (bool exist, bytes32 sig);
 }

--- a/contracts/interface/IXPool.sol
+++ b/contracts/interface/IXPool.sol
@@ -75,6 +75,8 @@ interface IXPool {
 
     function controller() external view returns (uint256);
 
+    function xconfig() external view returns (uint256);
+
     function getDenormalizedWeight(address) external view returns (uint256);
 
     function getTotalDenormalizedWeight() external view returns (uint256);


### PR DESCRIPTION
1. bug fix: 

issue29  加入 require(finalized, "ERR_NOT_FINALIZED");验证  https://github.com/xdefilab/xhalflife-base/issues/29

2. 添加SAFU治理功能：
(1) pool去重功能（hasPool / addPoolSig / removePoolSig）
判断pool重复的标准：
a：输入参数为（address[] memory tokens, uint256[] memory denorms），其中 token按照地址升序排列
b：对于每个token，计算normalized weight (精度100)：uint256 nWeight = denorms[i].mul(100).div(totalWeight);
c：计算整个pool的签名 
poolInfo = abi.encodePacked(poolInfo, tokens[i], nWeight);
sig = keccak256(poolInfo);
d: 根据 sig 判断是否已存在
e: 当一个池被抽干流动性后（池子issue的XPT数量接近0），将导致用户无法再添加资产，此时Proxy调用removePoolSig()删除签名，允许新建重复池
(2) 管理FarmPool （isFarmPool / addFarmPool / removeFarmPool）
(3) 一键将Altcoin兑换XDEX （convert）
(4) 将SAFU资产在任意池加入或者移除流动性 （joinPool / exitPool）
(5) 流动性XPT进行挖矿 (depositToFarm / withdrawFromFarm)
(6) burn XDEX （burnForSelf）
(7) 管理SAFU地址 （getSAFU / setSAFU）
(8) 核心管理员地址 （ getCore / setCore）
(9) 管理SwapProxy地址，配合SwapProxy合约迁移用（getSwapProxy / setSwapProxy） 
(10) 调整SAFU_FEE （getSafuFee / setSafuFee），初始值是 0.05%
(11) 调整MaxExitFee，初始值是 0.1%

